### PR TITLE
Fix stderr redirection

### DIFF
--- a/examples/config/fail/gobblefile.yml
+++ b/examples/config/fail/gobblefile.yml
@@ -1,0 +1,22 @@
+meta:
+  schema_version: 3
+global:
+  no_strict_host_key_checking: true
+  vars:
+    prefix: '[gobble]'
+    msg: Global Gobble!
+hosts:
+  all:
+    - ssh_target: localhost
+      vars:
+        ip: localhost
+        msg: Host Gobble!
+plays:
+  - name: Fail on purpose
+    hosts: [all]
+    sudo: false
+    tags: [setup]
+    tasks:
+      - name: Fail on purpose
+        command:
+          cmd: echo "Simulated error message" >&2 && exit 1

--- a/pkg/utils/exec_utils/exec_utils.go
+++ b/pkg/utils/exec_utils/exec_utils.go
@@ -12,12 +12,16 @@ import (
 )
 
 func RawExec(password string, cmd string, args ...string) error {
+	var stderrBuf bytes.Buffer
+
 	c := exec.Command(cmd, args...)
 	if password != "" {
 		c.Stdin = bytes.NewBufferString(password + "\n")
 	}
+	c.Stderr = &stderrBuf
 	err := c.Run()
-	return err
+
+	return fmt.Errorf("command failed: %v \nerror: %s", err, stderrBuf.String())
 }
 
 func RawExecStdout(cmd string, args ...string) error {


### PR DESCRIPTION
Gobble doesn't capture stderrors on targets. This fix adds stderr redirection. 
Before:
![image](https://github.com/sikalabs/gobble/assets/16418072/353f3ab9-8efd-46f3-8590-e9396edf6c39)
Fixed
![image](https://github.com/sikalabs/gobble/assets/16418072/f969fd80-54b3-4369-b680-0b32141d5a54)
